### PR TITLE
Fix `PATH` variable to support non standard brew

### DIFF
--- a/Formula/codeclimate.rb
+++ b/Formula/codeclimate.rb
@@ -10,7 +10,7 @@ class Codeclimate < Formula
   def install
     # Alter PATH to ensure `docker' is available
     system "env", \
-      "PATH=/usr/local/bin:#{ENV["PATH"]}", \
+      "PATH=#{HOMEBREW_PREFIX}/bin:#{ENV["PATH"]}", \
       "PREFIX=#{prefix}", "make", "install"
   end
 


### PR DESCRIPTION
The formulae fails when brew isn't installed on `/usr/local`, which is the case for [boxen](https://boxen.github.com) users (brew lives in `/opt/boxen/homebrew` here).
