### PR TITLE
Check for existence of sha1sum and exit early

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -5,6 +5,7 @@
 # Usage: bin/release VERSION
 #
 # Requires sha1sum be installed.
+# (OSX users may need to install brew package named 'md5sha1sum')
 #
 ###
 set -e


### PR DESCRIPTION
I ran into a couple issues running `/bin/release`. 
1. I didn't have sha1sum installed. The homebrew formula for it isn't a direct match, so I added a little print out in this PR on how to install it if it's not installed.
2. (Not resolved) Once I got past that, the script fails for me on OSX:

```
[2.1.2][11:22][~/p/homebrew-formulae (nd-check-sha1sum *)]$ ./bin/release "0.2.12"
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
Already up-to-date.
sed: 1: "Formula/codeclimate.rb": invalid command code F
```

/c @pbrisbin 
