### PR TITLE
Revert "Fix homebrew audit strict warnings"

### DIFF
--- a/Formula/codeclimate.rb
+++ b/Formula/codeclimate.rb
@@ -1,18 +1,19 @@
+require "formula"
+
 class Codeclimate < Formula
-  desc "Code Climate CLI"
+  CODECLIMATE_VERSION = "0.24.2".freeze
+
   homepage "https://github.com/codeclimate/codeclimate"
-  url "https://github.com/codeclimate/codeclimate/archive/v0.24.2.tar.gz"
-  sha256 "f6ab47d602c8a6ec2d4e9f86df829cc31c3059ad025058c7646499b154242351"
+  version CODECLIMATE_VERSION
+
+  url "https://github.com/codeclimate/codeclimate/archive/v#{CODECLIMATE_VERSION}.tar.gz"
+  sha1 "c28ce24aea878ecd8b1bd65cc313206bcd36aece"
 
   def install
     # Alter PATH to ensure `docker' is available
-    if Formula["docker"].linked_keg.exist?
-      ENV.prepend_path "PATH", Formula["docker"].opt_bin
-    end
-
-    ENV["PREFIX"] = prefix
-
-    system "make", "install"
+    system "env", \
+      "PATH=#{HOMEBREW_PREFIX}/bin:#{ENV["PATH"]}", \
+      "PREFIX=#{prefix}", "make", "install"
   end
 
   test do

--- a/bin/release
+++ b/bin/release
@@ -17,13 +17,19 @@ fi
 version=$1
 formula=Formula/codeclimate.rb
 
-sha256=$(curl -sL "https://github.com/codeclimate/codeclimate/archive/v$version.tar.gz" | shasum -a256 | cut -d " " -f 1)
+if ! command -v sha1sum > /dev/null 2>&1; then
+  echo "Please install the md5sha1sum package (`brew install md5sha1sum` on OS X)."
+  exit 1
+fi
+
+
+sha1=$(curl -sL "https://github.com/codeclimate/codeclimate/archive/v$version.tar.gz" | sha1sum | cut -d " " -f 1)
 
 git checkout master
 git pull
 
-sed 's/^\(.*\/v\).*\(.tar.gz"\)$/\1'"$version"'\2/' "$formula" > "$formula.modified"
-sed 's/^\(.*sha256 "\).*\(".*\)$/\1'"$sha256"'\2/' "$formula.modified" > "$formula"
+sed 's/^\(.*CODECLIMATE_VERSION = "\).*\(".*\)$/\1'"$version"'\2/' "$formula" > "$formula.modified"
+sed 's/^\(.*sha1 "\).*\(".*\)$/\1'"$sha1"'\2/' "$formula.modified" > "$formula"
 rm "$formula.modified"
 
 git add "$formula"


### PR DESCRIPTION
Reverts codeclimate/homebrew-formulae#23

This seems to be broken for users with `/usr/local/bin/docker` which, I think, is the default installation location of brew-installed dockers (`HOMEBREW_PREFIX` being `/usr/local`).
