### PR TITLE
Fix homebrew audit strict warnings, Allow non-brew Docker

### DIFF
--- a/Formula/codeclimate.rb
+++ b/Formula/codeclimate.rb
@@ -1,19 +1,18 @@
-require "formula"
-
 class Codeclimate < Formula
-  CODECLIMATE_VERSION = "0.24.3".freeze
-
+  desc "Code Climate CLI"
   homepage "https://github.com/codeclimate/codeclimate"
-  version CODECLIMATE_VERSION
-
-  url "https://github.com/codeclimate/codeclimate/archive/v#{CODECLIMATE_VERSION}.tar.gz"
-  sha1 "89da48bcc6e44a3546c0b730c4e2cc7535e79696"
+  url "https://github.com/codeclimate/codeclimate/archive/v0.24.3.tar.gz"
+  sha256 "70591e62a1c1dd61a56f133d0c0849fd94cfebf146bbdec765a9e01fffa75640"
 
   def install
     # Alter PATH to ensure `docker' is available
-    system "env", \
-      "PATH=#{HOMEBREW_PREFIX}/bin:#{ENV["PATH"]}", \
-      "PREFIX=#{prefix}", "make", "install"
+    if Formula["docker"].linked_keg.exist?
+      ENV.prepend_path "PATH", Formula["docker"].opt_bin
+    end
+
+    ENV["PREFIX"] = prefix
+
+    system "make", "install"
   end
 
   test do

--- a/Formula/codeclimate.rb
+++ b/Formula/codeclimate.rb
@@ -8,6 +8,8 @@ class Codeclimate < Formula
     # Alter PATH to ensure `docker' is available
     if Formula["docker"].linked_keg.exist?
       ENV.prepend_path "PATH", Formula["docker"].opt_bin
+    else
+      ENV.prepend_path "PATH", "/usr/local/bin"
     end
 
     ENV["PREFIX"] = prefix

--- a/bin/release
+++ b/bin/release
@@ -17,19 +17,13 @@ fi
 version=$1
 formula=Formula/codeclimate.rb
 
-if ! command -v sha1sum > /dev/null 2>&1; then
-  echo "Please install the md5sha1sum package (`brew install md5sha1sum` on OS X)."
-  exit 1
-fi
-
-
-sha1=$(curl -sL "https://github.com/codeclimate/codeclimate/archive/v$version.tar.gz" | sha1sum | cut -d " " -f 1)
+sha256=$(curl -sL "https://github.com/codeclimate/codeclimate/archive/v$version.tar.gz" | shasum -a256 | cut -d " " -f 1)
 
 git checkout master
 git pull
 
-sed 's/^\(.*CODECLIMATE_VERSION = "\).*\(".*\)$/\1'"$version"'\2/' "$formula" > "$formula.modified"
-sed 's/^\(.*sha1 "\).*\(".*\)$/\1'"$sha1"'\2/' "$formula.modified" > "$formula"
+sed 's/^\(.*\/v\).*\(.tar.gz"\)$/\1'"$version"'\2/' "$formula" > "$formula.modified"
+sed 's/^\(.*sha256 "\).*\(".*\)$/\1'"$sha256"'\2/' "$formula.modified" > "$formula"
 rm "$formula.modified"
 
 git add "$formula"


### PR DESCRIPTION
This restores the changes from #23, with the addition of allowing installation with configurations where `docker` was not installed via Homebrew.

cc @codeclimate/review 
